### PR TITLE
Make require_ruby_for_busser consistent w/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ platforms:
 By default test-kitchen installs chef to get a ruby version suitable to run serverspec in the `verify` step.
 Instead ruby can just be installed by specifying the provisioner option:
 
-```
-require_ruby_for_busser: false
+```yaml
+require_ruby_for_busser: true
 ```
 And set the verifier section:
 ```


### PR DESCRIPTION
Since `require_ruby_for_busser` needs to be `true` for ruby to be installed for the Busser, and we're talking about using ruby in the blip directly above, this snippet should set the busser to `true`.
